### PR TITLE
jest fix for react-native-elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4430,6 +4430,12 @@
         "har-schema": "2.0.0"
       }
     },
+    "harmony-reflect": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.5.1.tgz",
+      "integrity": "sha1-tUymF7AMyK71Wbuxez2FQx3H4yk=",
+      "dev": true
+    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -4619,6 +4625,15 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "1.5.1"
+      }
     },
     "idx": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "react-native-scripts": "1.11.1",
+    "identity-obj-proxy": "^3.0.0",
     "jest-expo": "25.0.0",
+    "react-native-scripts": "1.11.1",
     "react-test-renderer": "16.2.0"
   },
   "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
@@ -16,7 +17,10 @@
     "test": "node node_modules/jest/bin/jest.js"
   },
   "jest": {
-    "preset": "jest-expo"
+    "preset": "jest-expo",
+    "moduleNameMapper": {
+      ".+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$": "identity-obj-proxy"
+    }
   },
   "dependencies": {
     "expo": "^25.0.0",


### PR DESCRIPTION
wanted to start writing some tests, but jest tests were failing when react-native-elements components were imported.  

found a fix on this thread after a bazillion google searches:
https://github.com/facebook/jest/issues/2663

adding the moduleNameMapper did the trick.

thanks to magnusart, our tests will pass again now.  well, our test.  we still have to write some. 😺 

