### PR TITLE
removing typo in package.json that was causing start to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
   "scripts": {
-    "start": "react-native-scripts start",git
+    "start": "react-native-scripts start",
     "eject": "react-native-scripts eject",
     "android": "react-native-scripts android",
     "ios": "react-native-scripts ios",


### PR DESCRIPTION
i was dumb and had a typo in package.json, must have had my cursor in the wrong window. shouldn't merge my own code but don't want you to have to figure out what dumb thing i did next time you start after you pull so i'm gonna merge this one.