### PR TITLE
Fix failing test for App

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,6 +3,7 @@ import HomeScreen from './src/components/HomeScreen/HomeScreen';
 import AddScreen from './src/components/AddScreen/AddScreen';
 import {StackNavigator} from 'react-navigation';
 import {Font} from "expo";
+import {StyleSheet, View} from 'react-native';
 
 import listData from './src/assets/mockData.json';
 
@@ -77,14 +78,20 @@ export default class App extends React.Component {
     }
     render() {
         return (
-            <React.Fragment>
+            <View style={styles.container}>
                 {this.state.fontLoaded ? (
                     //this isn't optimal passing everything to all screens but we'll fix that when we add redux
                     <RootStack screenProps={{list: this.state.list, addItem: this.addItem, handleUpdateStatus: this.updateStatus}}/>
                 ) : null
                 }
-            </React.Fragment>
+            </View>
 
         );
     }
 }
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1
+    }
+});

--- a/App.test.js
+++ b/App.test.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import App from './App';
 
-import renderer from 'react-test-renderer';
+import TestRenderer from 'react-test-renderer';
 
 it('renders without crashing', () => {
-    const wrapper = renderer.create(<App/>).toJSON();
+    const wrapper = TestRenderer.create(<App/>).toJSON();
+    console.log(wrapper);
     expect(wrapper).toBeTruthy();
     expect(wrapper).toMatchSnapshot();
 });

--- a/App.test.js
+++ b/App.test.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import App from './App';
 
-import TestRenderer from 'react-test-renderer';
+import renderer from 'react-test-renderer';
 
 it('renders without crashing', () => {
-    const wrapper = TestRenderer.create(<App/>).toJSON();
-    console.log(wrapper);
+    const wrapper = renderer.create(<App/>).toJSON();
     expect(wrapper).toBeTruthy();
     expect(wrapper).toMatchSnapshot();
 });

--- a/__snapshots__/App.test.js.snap
+++ b/__snapshots__/App.test.js.snap
@@ -1,3 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders without crashing 1`] = `null`;
+exports[`renders without crashing 1`] = `
+<View
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+/>
+`;


### PR DESCRIPTION
the failing app test was bugging me.  i googled but didn't find anything but then on a whim tried changing the React.Fragment wrapper back to View the way it used to be.  that did the trick.  so something somewhere in our test framework doesn't like React.Fragment.

Now that we've got this figured out, we should at least write render tests for all of our components.