### PR TITLE
fix for Issue #50 (button group error on deselect)

### DIFF
--- a/src/components/AddScreen/AddScreen.js
+++ b/src/components/AddScreen/AddScreen.js
@@ -55,44 +55,23 @@ export default class AddScreen extends React.Component {
     };
 
 
+    handleButtonGroupSelection = (buttonGroup, list, selectedIndex) => {
+        //make a copy of state so we're not mutating it directly
+        let newState = Object.assign({}, this.state);
 
-
-    //todo these two functions could probably be refined and put into one thing
-    //duplicating too much here
-
-    handleTeaSelection = (selectedIndex) => {
-        let selectedTea;
         //we don't require tea, so if the user pushes a tea button that is already selected
         //let's deselect it.
-        if(selectedIndex === this.state.teaSelectedIndex) {
-            selectedTea = -1;
+        if(selectedIndex === this.state[buttonGroup + 'SelectedIndex']) {
+            newState[buttonGroup + 'SelectedIndex'] = -1;
         } else {
-            selectedTea = selectedIndex;
+            newState[buttonGroup + 'SelectedIndex'] = selectedIndex;
+            newState[buttonGroup + 'SelectedType'] = list[selectedIndex].type;
         }
-        this.setState({
-            teaSelectedIndex: selectedTea,
-            teaSelectedType: teaList.list[selectedTea].type
-        });
-    };
 
-    handleCategorySelection = (selectedIndex) => {
-        let selectedCategory;
-        //we don't require category, so if the user pushes a tea button that is already selected
-        //let's deselect it.
-        if(selectedIndex === this.state.categorySelectedIndex) {
-            selectedCategory = -1;
-        } else {
-            selectedCategory = selectedIndex;
-        }
-        this.setState({
-            categorySelectedIndex: selectedCategory,
-            categorySelectedType: categoryList.list[selectedCategory].type
-        })
+        this.setState(newState);
     };
 
     render() {
-
-
         return (
             <React.Fragment>
                 <ScrollView style={styles.container}>
@@ -116,16 +95,15 @@ export default class AddScreen extends React.Component {
                     <ButtonGroup
                         buttons={this.generateButtonList(teaList.list)}
                         selectedIndex={this.state.teaSelectedIndex}
-                        onPress={this.handleTeaSelection}
+                        onPress={(event) => this.handleButtonGroupSelection("tea", teaList.list, event)}
                         selectedButtonStyle={styles.selectedButton}
-                        selectedTextStyle={styles.selectedButtonText}
 
                     />
 
                     <ButtonGroup
                         buttons={this.generateButtonList(categoryList.list,true)}
                         selectedIndex={this.state.categorySelectedIndex}
-                        onPress={this.handleCategorySelection}
+                        onPress={(event) => this.handleButtonGroupSelection("category", categoryList.list, event)}
                         selectedButtonStyle={styles.selectedButton}
                     />
                     <TouchableOpacity onPress={this.handleAddItem}>


### PR DESCRIPTION
- the error that would occur when user clicked a ButtonGroup button twice to deselect was caused by the handlers trying to get the type of tea or category selected when there was no selection.  
- issue was fixed by only setting that if the index was not -1 (the index for no selection)
- also did the todo for refactoring the handleTeaSelection and handleCategorySelection functions into one reusable function, handleButtonGroupSelection, since nearly everything in them was duplicated except for property names.  
- because the property names are different for tea and category (like teaSelectedIndex and teaSelectedType), we now need to pass the handler the buttonGroup so we can assign the appropriate prefix to those properties as well as the list of possible choices.

side by side diff is a little easier to read on this one.  I should have done the bug fix in a separate pull request from the refactor so that it was easier to see what I did.  lesson learned.